### PR TITLE
Added publish.yaml status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # charmcraftcache
+[![Publish](https://github.com/canonical/charmcraftcache/actions/workflows/publish.yaml/badge.svg)](https://github.com/canonical/charmcraftcache/actions/workflows/publish.yaml)
+
 _Reinventing the wheel_
 
 Fast first-time builds for [charmcraft](https://github.com/canonical/charmcraft)—on a local machine or CI


### PR DESCRIPTION
Added status badge so CI status gets displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.
